### PR TITLE
Persistence with database and global chat

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,7 +27,22 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-jwt</artifactId>
+			<version>1.1.1.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/backend/src/main/java/com/example/backend/config/WebSecurity.java
+++ b/backend/src/main/java/com/example/backend/config/WebSecurity.java
@@ -1,0 +1,46 @@
+package com.example.backend.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurity extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors()
+                .and()
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/ws/**").permitAll()
+                .anyRequest().permitAll()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+        configuration.applyPermitDefaultValues();
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/backend/src/main/java/com/example/backend/controller/MessageController.java
+++ b/backend/src/main/java/com/example/backend/controller/MessageController.java
@@ -1,0 +1,35 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.Message;
+import com.example.backend.response.MessageResponse;
+import com.example.backend.service.MessageService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@RestController
+public class MessageController {
+    @Autowired
+    private MessageService messageService;
+
+    @PostMapping("/message")
+    public ResponseEntity<String> saveBid(@RequestBody Message message) {
+        return ResponseEntity.ok(messageService.saveMessage(message));
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<List<MessageResponse>> getMessages() {
+        return ResponseEntity.ok(new ArrayList<MessageResponse>(messageService.getMessages()));
+    }
+}

--- a/backend/src/main/java/com/example/backend/model/Message.java
+++ b/backend/src/main/java/com/example/backend/model/Message.java
@@ -1,10 +1,27 @@
 package com.example.backend.model;
 
+import javax.persistence.*;
+
+@Entity
+@Table(name = "message")
 public class Message {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "sendername")
     private String senderName;
+
+    @Column(name = "receivername")
     private String receiverName;
+
+    @Column(name = "message")
     private String message;
+
+    @Column(name = "date")
     private String date;
+
+    @Column(name = "status")
     private Status status;
 
     public Message(String senderName, String receiverName, String message, String date, Status status) {

--- a/backend/src/main/java/com/example/backend/response/MessageResponse.java
+++ b/backend/src/main/java/com/example/backend/response/MessageResponse.java
@@ -1,0 +1,22 @@
+package com.example.backend.response;
+
+public class MessageResponse {
+    private String senderName;
+    private String message;
+
+    public MessageResponse(String senderName, String message) {
+        this.senderName = senderName;
+        this.message = message;
+    }
+
+    public MessageResponse() {
+    }
+
+    public String getSenderName() {
+        return senderName;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/example/backend/service/MessageService.java
+++ b/backend/src/main/java/com/example/backend/service/MessageService.java
@@ -1,0 +1,62 @@
+package com.example.backend.service;
+
+import com.example.backend.model.Message;
+import com.example.backend.response.MessageResponse;
+import com.example.backend.store.MessageRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class MessageService {
+    @Autowired
+    private MessageRepository messageRepository;
+
+    private static String secret;
+    private static int expiration_time;
+
+    @Value("${jwt.secret}")
+    public void setJWTSecret(String secret) {
+        this.secret = secret;
+    }
+
+    @Value("${jwt.expirationTime}")
+    public void setJWTExpiration(int expiration_time) {
+        this.expiration_time = expiration_time;
+    }
+
+    public MessageService() {
+    }
+
+    private List<MessageResponse> returnNewList(List<Message> list) {
+        return list.stream().map(p -> new MessageResponse(
+                p.getSenderName(),
+                p.getMessage())).collect(Collectors.toList());
+    }
+
+    public String saveMessage(Message message) {
+        messageRepository.save(message);
+        return "Okay";
+    }
+
+    public List<MessageResponse> getMessages() {
+        List<Message> list = messageRepository.findAll();
+        return returnNewList(list);
+    }
+
+    public String getToken(String name) {
+        String JWT = Jwts.builder()
+                .setSubject(name)
+                .setExpiration(new Date(System.currentTimeMillis() + expiration_time))
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+
+        return JWT;
+    }
+}

--- a/backend/src/main/java/com/example/backend/store/MessageRepository.java
+++ b/backend/src/main/java/com/example/backend/store/MessageRepository.java
@@ -1,0 +1,13 @@
+package com.example.backend.store;
+
+import com.example.backend.model.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MessageRepository extends JpaRepository<Message, Integer> {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.datasource.url = jdbc:postgresql://lucky.db.elephantsql.com/pchwrhca
 
 spring.datasource.username = pchwrhca
 spring.datasource.password = Ihs0sqwvZvfud_Lpn8XtPLdR4-wvT5HT
+
+jwt.secret = javainuse
+jwt.expirationTime = 864000000

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.1.3",
         "bootstrap": "^5.2.2",
         "net": "^1.0.2",
         "react": "^18.2.0",
@@ -5047,6 +5048,29 @@
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14109,6 +14133,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -20901,6 +20930,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
     },
+    "axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -27290,6 +27341,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.1.3",
     "bootstrap": "^5.2.2",
     "net": "^1.0.2",
     "react": "^18.2.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import Navbar from "./components/Navbar";
 import { uniqueNamesGenerator, Config, adjectives, colors, animals } from 'unique-names-generator';
 import {over} from 'stompjs';
 import SockJS from "sockjs-client";
+import { getMessages, sendMessage } from "./services/MessageService";
 var stompClient = null;
 
 function App() {
@@ -23,6 +24,11 @@ function App() {
 
   useEffect(() => {
     const randomName = uniqueNamesGenerator({ dictionaries: [colors, animals] });
+    getMessages().then(res => {
+      setGlobalChat(res.data);
+    }).catch((err) => {
+      console.log(err);
+    })
     setUserData({...userData, "username":randomName});
   }, []);
 
@@ -78,13 +84,13 @@ function App() {
     let payloadData = JSON.parse(payload.body);
     if(privateChat.get(payloadData.senderName)) {
       privateChat.get(payloadData.senderName).push(payloadData);
-      alert(userData.username + " sent you a message!");
+      alert(payloadData.senderName + " sent you a message!");
       setPrivateChat(new Map(privateChat));
     } else {
       let list = [];
       list.push(payloadData);
       privateChat.set(payloadData.senderName, list);
-      alert(userData.username + " sent you a message!");
+      alert(payloadData.senderName + " sent you a message!");
       setPrivateChat(new Map(privateChat));
     }
   }
@@ -96,6 +102,11 @@ function App() {
         message: userData.message,
         status: 'MESSAGE'
       };
+      sendMessage(chatMessage).then(res => {
+        console.log(res.data);
+      }).catch((err) => {
+        console.log(err);
+      }) 
       stompClient.send('/app/message', {}, JSON.stringify(chatMessage));
       setUserData({...userData, "message": ""})
     }

--- a/frontend/src/services/MessageService.js
+++ b/frontend/src/services/MessageService.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const url = "http://localhost:8080";
+
+export const getMessages = async () => {
+    return await axios.get( url + "/messages");
+}
+
+export const sendMessage = async (message) => {
+    return await axios.post(url + "/message", message);
+}


### PR DESCRIPTION
This branch completes the persistence functionality on the global chat in the application. The chat application was given a database connection to keep the messages being sent on the global chatroom so they stay for users just getting in the app.
On every application load a call is made to the backend which takes the messages and gives them to the frontend to show. The functionality is primitive at the time because it wasn't given a higher solution like pagination to load messages on command.